### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-imagedir = Pkg.dir("TestImages", "images")
+imagedir = joinpath(dirname(@__FILE__), "..", "images")
 if !isdir(imagedir)
     mkdir(imagedir)
 end

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -3,7 +3,7 @@ using Images
 
 export testimage
 
-const imagedir = joinpath(Pkg.dir(), "TestImages", "images")
+const imagedir = joinpath(dirname(@__FILE__), "..", "images")
 
 REPO_URL = "https://github.com/timholy/TestImages.jl/blob/gh-pages/images/"
 


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done.